### PR TITLE
feat: wake up server on app start and show disclaimer

### DIFF
--- a/apps/client/src/domains/SidePanel/SidePanel.tsx
+++ b/apps/client/src/domains/SidePanel/SidePanel.tsx
@@ -4,13 +4,15 @@ import { Engine } from '@common/schemas/routing';
 
 import { useStore } from '@/services';
 import { Error } from '@/shared/ui';
+import { useAlarm } from '@/shared/helpers';
 
 import { Route } from './ui';
 import s from './SidePanel.module.css';
 
 export const SidePanel = () => {
+  useAlarm();
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const { routes, setActiveEngines, setPath } = useStore();
+  const { routes, setActiveEngines, setPath, isServerAwake } = useStore();
 
   const handleClick = () => {
     setIsCollapsed(!isCollapsed);
@@ -48,6 +50,9 @@ export const SidePanel = () => {
               Clear route
             </button>
           </section>
+        )}
+        {isServerAwake === false && (
+          <Error message="Server is sleeping. Wait a bit..." />
         )}
         <Error message={routes.graphhopper.error} />
       </div>

--- a/apps/client/src/services/api/apiRoutes.ts
+++ b/apps/client/src/services/api/apiRoutes.ts
@@ -8,3 +8,9 @@ export const fetchRoute = async (payload: ProxyServerPayload) => {
     payload,
   });
 };
+
+export const checkHealth = async () => {
+  return apiService.get({
+    url: '/api/health',
+  });
+};

--- a/apps/client/src/services/api/index.ts
+++ b/apps/client/src/services/api/index.ts
@@ -1,2 +1,3 @@
 export { apiService } from './apiService';
 export { GraphHopperLimitError } from './apiErrors';
+export { checkHealth, fetchRoute } from './apiRoutes';

--- a/apps/client/src/services/store/useStore.tsx
+++ b/apps/client/src/services/store/useStore.tsx
@@ -14,6 +14,8 @@ export type Store = {
   setPath: (engine: Engine, path: Path | undefined) => void;
   setError: (err: string) => void;
   setActiveEngines: (engine: Engine) => void;
+  isServerAwake: boolean | undefined;
+  setServerAwake: (isAwake: boolean) => void;
 };
 
 export const useStore = create<Store>()(
@@ -64,5 +66,7 @@ export const useStore = create<Store>()(
           },
         },
       })),
+    isServerAwake: undefined,
+    setServerAwake: (isAwake) => set({ isServerAwake: isAwake }),
   })),
 );

--- a/apps/client/src/shared/helpers/index.ts
+++ b/apps/client/src/shared/helpers/index.ts
@@ -1,3 +1,4 @@
 export { getRetinaMod } from './getRetinaMod';
 export { EventEmitter } from './EventEmitter';
 export * from './route';
+export { useAlarm } from './useAlarm';

--- a/apps/client/src/shared/helpers/useAlarm.ts
+++ b/apps/client/src/shared/helpers/useAlarm.ts
@@ -13,21 +13,36 @@ export const useAlarm = () => {
       return;
     }
 
+    let isCancelled = false;
+
     Promise.race([
       new Promise((_resolve, reject) => setTimeout(reject, TIMEOUT)),
       checkHealth(),
     ])
       .catch(() => {
+        if (isCancelled) {
+          return;
+        }
         setServerAwake(false);
         return checkHealth();
       })
       .then(
         () => {
+          if (isCancelled) {
+            return;
+          }
           setServerAwake(true);
         },
         () => {
+          if (isCancelled) {
+            return;
+          }
           setServerAwake(false);
         },
       );
+
+    return () => {
+      isCancelled = true;
+    };
   }, [setServerAwake, isServerAwake]);
 };

--- a/apps/client/src/shared/helpers/useAlarm.ts
+++ b/apps/client/src/shared/helpers/useAlarm.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+
+import { checkHealth } from '@/services/api';
+import { useStore } from '@/services/store/useStore';
+
+const TIMEOUT = 500;
+// wake up server which sleeps after 15 min of inactivity on Render
+export const useAlarm = () => {
+  const { setServerAwake, isServerAwake } = useStore();
+
+  useEffect(() => {
+    if (isServerAwake) {
+      return;
+    }
+
+    Promise.race([
+      new Promise((_resolve, reject) => setTimeout(reject, TIMEOUT)),
+      checkHealth(),
+    ])
+      .catch(() => {
+        setServerAwake(false);
+        return checkHealth();
+      })
+      .then(
+        () => {
+          setServerAwake(true);
+        },
+        () => {
+          setServerAwake(false);
+        },
+      );
+  }, [setServerAwake, isServerAwake]);
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - App now auto-checks server health and attempts to wake it if asleep.
  - Side Panel displays “Server is sleeping. Wait a bit...” when the server isn’t ready.

- Improvements
  - More robust handling of API responses that aren’t JSON, reducing unexpected errors.
  - Clearer error messages for routing and rate-limit scenarios.

- Chores
  - Health-check helper and alarm hook exposed for use across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->